### PR TITLE
Date and teaser subtitle

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -52,7 +52,15 @@
 
           <img src="assets/images/logos/scalaio/scalaio_medium.png" alt="Scala.IO logo" />
           <h1>The Scala event in France! </h1>
-          <h2 class="teaser-subtitle"><span class="teaser-subtitle-text">October 27th and 28th, 2016. <span class="red">Lyon</span>, France</span><a href="https://twitter.com/share" class="twitter-share-button" data-via="ScalaIO_FR" data-size="large" data-count="none"><span class="tsb1">Tweet</span></a></h2>
+          <p class="teaser-subtitle">
+            <h2>October 27th - 28th 2016</h2>
+          </p>
+          <p class="teaser-subtitle">
+            CPE, <span class="red">Lyon</span>, France</span>
+          </p>
+          <p class="teaser-subtitle">
+            <span><a href="https://twitter.com/share" class="twitter-share-button" data-via="ScalaIO_FR" data-size="large" data-count="none"><span class="tsb1">Tweet</span></a></span>
+          </p>
           <script>
           !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
           </script>

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,6 @@ title: Scala.IO conference
       <p class="main_title" > is ON!</p>
 
       <p class="main_heading" >
-        27th - 28th of October in <span class="red">Lyon</span>, France
         <iframe class="maps-landing" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5712640.860687742!2d-0.44979880811407663!3d46.59797712311206!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47f4ea516ae88797%3A0x408ab2ae4bb21f0!2sLyon!5e0!3m2!1sen!2sfr!4v1455549076048" frameborder="0" style="border:0" allowfullscreen></iframe>
       </p>
       <!--


### PR DESCRIPTION
Removed redundant date on home page and formatted teaser subtitle on three lines (date, location and twitter share)
