### PR TITLE
CFP titles formatting

### DIFF
--- a/src/cfp.md
+++ b/src/cfp.md
@@ -11,42 +11,42 @@ The annual Scala.IO conference is a place where people can see how others are us
 If you have experience using Scala or a functional programming languages, we invite you to submit a proposal to give a talk at the conference.
 Except for lightning talks, if your submission gets accepted you'll get a free pass for the conference (up to 2 speakers).
 
-<em>Kind of talks</em>
+### Kind of talks
 
-### Short Conference (20 minutes)
+#### Short Conference (20 minutes)
 
 Normal technical or report are typically 20 minutes long. They aim to inform participants about how Scala or a functional programming language plays out in real-world applications, focusing especially on lessons learned and insights gained. Experience reports do not need to be highly technical; reflections on the commercial, management, or software engineering aspects are, if anything, more important.
 
-### Conference (45 minutes)
+#### Conference (45 minutes)
 
 Long talks are around 45 minutes long, and should focus on teaching the audience something about a particular technique or methodology, from the point of view of someone who has seen it played out in practice. These talks could cover anything from techniques for building functional concurrent applications, to managing dynamic reconfigurations, to design recipes for using types effectively in large-scale applications. These talks should be accessible to a broad range of programmers.
 
-### Lightning talks (10 minutes - during lunch)
+#### Lightning talks (10 minutes - during lunch)
 
 Lightning talks are a great way to introduce a subject you like or deeply care about to a smaller audience. They are an opportunity for every speakers to communicate at a more personnal level.
 
-### Workshop (3h00)
+#### Workshop (3h00)
 
 Workshops are 3 hours long. They aim to teach participant concrete skills about Scala usage. Workshops are essentially practical sessions. Participants are expected to practice in live, on their own laptop or a computer provided by Scala.io (if available). Workshops also are intended for the participants to share with the speakers. Workshops will require a specific planning and setup (we are working on it), we will contact you for organisation details.
 
-<em>Talks subjects</em>
+### Talks subjects
 
 In the CFP application speakers will be asked to choose a category or "track" for their talks. This section gives some guidance on how to match your talk with the following categories. The categories are mostly here to help attendees make a quicker selection and for the cfp team to get a balanced content.
 Don't fret too much on finding the right category if you think your talk matches multiple categories. Just choose what you feel is the best match. The cfp team will discuss ambiguous proposals with the speaker(s) if needed.
 
-### Scala & ecosystem (scala, librarires, new projects, retours d'experience,etc)
+#### Scala & ecosystem (scala, librarires, new projects, retours d'experience,etc)
 Of course Scala.IO has a special place for scala and the related ecosystem of libraries and projects. Talks presenting new scala features, scala tooling news, new libraries or experience summaries with using scala at work should probably go there.
 
-### Functional Languages
+#### Functional Languages
 Scala.IO is not only about scala. We consider that the scala and functional programming communities have a lot in common and can learn a lot from each other. Therefore talks presenting concepts or ideas or idiomatic ways to solve problems in other languages are welcome in this section.
 
-### Typelevel Functional programming
+#### Typelevel Functional programming
 Talks focusing on advanced scala features, meta programming with macros, complext type manipulation and computation, new type techniques, advanced functional programming and supporting libraries.
 
-### Big data / Machine learning
+#### Big data / Machine learning
 Big data and machine learning are a big driver of the scala ecosystem. Spark based of course but also NLP and immutable graph processing, scaling architectures, etc, are probably a good fit for this category.
 
-### Scala University
+#### Scala University
 This is new this year, we have met many developers who have looked / are looking at scala but are unsure how to get started with it at work, how to introduce it to their team. This category is to create a "getting started" track for these people : from the scala basics to starting your project, how to integrate scala and the scala tests frameworks in a java project, how to organise a scala code base, which frameworks/libs can help bootstrap your use of scala, how to get started with functional programming, common patterns in scala, etc.
 Help us turn enthousiasts into evangelists ! :)
 


### PR DESCRIPTION
Les titres "Kind of talks" et "Talks subjects" ne sont pas du bon niveau.  Ils devraient être de niveau h3 et leurs sous-titres de niveau h4
